### PR TITLE
fix: manual naming update for cu13

### DIFF
--- a/cu130/sgl-kernel/index.html
+++ b/cu130/sgl-kernel/index.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <h1>SGLang Kernel Library Wheels for CUDA 13.0</h1>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post4/sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_aarch64.whl#sha256=3d1069ab7a263b4225292cd0b30bc271ee10edc9ebc254d26622c17c83979c46">sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post4/sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_x86_64.whl#sha256=7a7f8fe6fe83aaefe92f3d1e88a270955a444df2ae7fd8bb43933ad51622c9db">sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post4/sgl_kernel-0.3.16.post4+cu13-cp310-abi3-manylinux2014_aarch64.whl#sha256=3d1069ab7a263b4225292cd0b30bc271ee10edc9ebc254d26622c17c83979c46">sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post4/sgl_kernel-0.3.16.post4+cu13-cp310-abi3-manylinux2014_x86_64.whl#sha256=7a7f8fe6fe83aaefe92f3d1e88a270955a444df2ae7fd8bb43933ad51622c9db">sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_x86_64.whl</a><br>


### PR DESCRIPTION
I've updated the naming scheme for the cu13 kernel in [ca001b3](https://github.com/sgl-project/sglang/pull/11517/commits/ca001b37b1393d3633a9942013601c3f10286c52). Shouldn't have to do this in the future