### PR TITLE
[AMD] Adding index for rocm700

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,3 +5,4 @@
 <a href="cu128/">cu128</a><br>
 <a href="cu129/">cu129</a><br>
 <a href="cu130/">cu130</a><br>
+<a href="rocm700/">rocm700</a><br>

--- a/rocm700/index.html
+++ b/rocm700/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<a href="sgl-kernel/">sgl-kernel</a>

--- a/rocm700/sgl-kernel/index.html
+++ b/rocm700/sgl-kernel/index.html
@@ -1,1 +1,2 @@
-<a href="https://github.com/RohitNagraj/sglang-whl/releases/download/v0.3.19/sgl_kernel-0.3.19+rocm700-cp310-abi3-manylinux2014_x86_64.whl#sha256=b914c2c46cffa2af51ece2c572683f1748243d08a56977b178db363f43ca7dee">sgl_kernel-0.3.19+rocm700-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<!DOCTYPE html>
+<h1>SGLang Kernel Library Wheels for ROCm 7.0</h1>

--- a/rocm700/sgl-kernel/index.html
+++ b/rocm700/sgl-kernel/index.html
@@ -1,0 +1,1 @@
+<a href="https://github.com/RohitNagraj/sglang-whl/releases/download/v0.3.19/sgl_kernel-0.3.19+rocm700-cp310-abi3-manylinux2014_x86_64.whl#sha256=b914c2c46cffa2af51ece2c572683f1748243d08a56977b178db363f43ca7dee">sgl_kernel-0.3.19+rocm700-cp310-abi3-manylinux2014_x86_64.whl</a><br>


### PR DESCRIPTION
Added and updated index for rocm700. This comes as an addition to [this PR](https://github.com/sgl-project/sglang/pull/14684) on the `sglang` repo that builds sgl-kernel for rocm700 for AMD.