### PR TITLE
Add rocm700

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,3 +5,4 @@
 <a href="cu128/">cu128</a><br>
 <a href="cu129/">cu129</a><br>
 <a href="cu130/">cu130</a><br>
+<a href="rocm700/">rocm700</a><br>

--- a/rocm700/index.html
+++ b/rocm700/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<a href="sgl-kernel/">sgl-kernel</a>

--- a/rocm700/sgl-kernel/index.html
+++ b/rocm700/sgl-kernel/index.html
@@ -1,1 +1,3 @@
+<!DOCTYPE html>
+<h1>SGLang Kernel Library Wheels for ROCm 7.0</h1>
 <a href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20+rocm700-cp310-abi3-manylinux2014_x86_64.whl#sha256=b1535a426316ca35bab4c6f8f1cbde1203f1da454dae427af3073b956d835b35">sgl_kernel-0.3.20+rocm700-cp310-abi3-manylinux2014_x86_64.whl</a><br>


### PR DESCRIPTION
Update the index pages as https://github.com/sgl-project/sglang/pull/15627 is about to be merged.  The reason that `rocm700/sgl-kernel/index.html` already has an entry is because of [the test](https://github.com/sgl-project/sglang/actions/runs/20739552798) of the PR.