### PR TITLE
fix: updating new hash

### DIFF
--- a/cu129/sgl-kernel/index.html
+++ b/cu129/sgl-kernel/index.html
@@ -1,190 +1,96 @@
 <!DOCTYPE html>
 <h1>SGLang Kernel Library Wheels for CUDA 12.9</h1>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.3/sgl_kernel-0.3.3-cp39-abi3-manylinux2014_x86_64.whl#sha256=6baa35a48e3f3d0ac9e764d19e9706c5fca2ed1b2b6d21327d930bccbf15812f">sgl_kernel-0.3.3-cp39-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.4/sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=8c1093880a90c9768c4419e1bbc8cb9788296432b498c38f41844796fe2b3dac">sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.4/sgl_kernel-0.3.4+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=0241d5bfbf6cc6117c6366941f2ec4e777ea4ad5df1a44342b00c1f812642c0a">sgl_kernel-0.3.4+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.4/sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=f95cd55d3da3a2f5f4bde6950f14c0f342ee888f7fecb58e366d34003365b346">sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.4/sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=8c1093880a90c9768c4419e1bbc8cb9788296432b498c38f41844796fe2b3dac">sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.4.post1/sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=3ec5dac4da6edff73e6225435034aee92b469c51c4a69137786329c57b72ca59">sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.4.post1/sgl_kernel-0.3.4.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=3ac1df6283976723afe3f5daa2d6e4ea1d3ac23850b397dd5612a2fc986face0">sgl_kernel-0.3.4.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.4.post1/sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=9218d6107cb5bda1c15b2657ced4a75bfddf680c1a4b4821121d760f776bceed">sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.4.post1/sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=3ec5dac4da6edff73e6225435034aee92b469c51c4a69137786329c57b72ca59">sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.5/sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=861652872549a802b72922fc995ff2a58901db6d8d34fabe68fe00ef939fd768">sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.5/sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=3a602ac4a545ef4c5b2804680fcdf29d7468eae49f4dcc00e765f6d2932d1860">sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.5/sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=861652872549a802b72922fc995ff2a58901db6d8d34fabe68fe00ef939fd768">sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.6/sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=c63d740a63ee944f6e5bff15546515576565a2fea1cdddb99bcdea293ff2b028">sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.6/sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=c63d740a63ee944f6e5bff15546515576565a2fea1cdddb99bcdea293ff2b028">sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.6/sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=42abd39be44154d34298d7f2ad142dda74f945a0cf0340b99bef90b9a5358ff1">sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.6.post1/sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=8638121325827576e8996e009297efa4f59d7fbcc00324ad217f05886db7a3f7">sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.6.post1/sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=f934b46d65f7e9788e31f0b029e03b02da7971c3f1944779fe3f36eba561c2f9">sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.6.post1/sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=8638121325827576e8996e009297efa4f59d7fbcc00324ad217f05886db7a3f7">sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.6.post2/sgl_kernel-0.3.6.post2+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=6bdde60513ccfd2d7e590ceebaca66b72455b3f5e53ce5b5e7eae4ccda88ed26">sgl_kernel-0.3.6.post2+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.7/sgl_kernel-0.3.7+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=da4665c036f8ec4ed3079326022ee24f3a72dc90bd3d71e4d68762f570fc5a3d">sgl_kernel-0.3.7+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.7.post1/sgl_kernel-0.3.7.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=e3638db21650e15a8577eccbef851d808f6ac0ed9d7fed9c28cd4c6756bb52ec">sgl_kernel-0.3.7.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.8/sgl_kernel-0.3.8+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=bafefcfe2ef1d303fcca7d48fff13ab307b62ccb9f19a4ffc4c21d5128c61a8b">sgl_kernel-0.3.8+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.9/sgl_kernel-0.3.9+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=30ccbe21a0665e8887ef65a0993e80c74a963fb021cf67b85a62e6e6aa207b03">sgl_kernel-0.3.9+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.9/sgl_kernel-0.3.9+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=1612c6af52db870260cb9042edcad1c67e3d07fcce6e65bc4b85c290377dfada">sgl_kernel-0.3.9+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.9/sgl_kernel-0.3.9-cp310-abi3-manylinux2014_aarch64.whl#sha256=e4d623154e81b5e47e9ad0ad8ad5509f0255c8826205e62f097a52193eb7675f">sgl_kernel-0.3.9-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post1/sgl_kernel-0.3.9.post1+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=34520cfdf08d97ea9bdd5edcad4a6b317b79a67c073d3a44f5a8f52da83c3ebe">sgl_kernel-0.3.9.post1+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post1/sgl_kernel-0.3.9.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=e26d05487c23e76e08804c05531fa76e52b058a7b71e427c0152b825f71bd6a4">sgl_kernel-0.3.9.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post1/sgl_kernel-0.3.9.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=1d11eea249f38fa6ec151460d805ba0240f382262195d22d0419ad7b8b17278b">sgl_kernel-0.3.9.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post2/sgl_kernel-0.3.9.post2+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=357eb2a4de102332460bddca26b5b0f982b850e9af0a49c9f7677018e3c3583c">sgl_kernel-0.3.9.post2+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post2/sgl_kernel-0.3.9.post2+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=efcd8b29773583829021a1380213cc826967a2562242cbefba4f0c36ee18bf8c">sgl_kernel-0.3.9.post2+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post2/sgl_kernel-0.3.9.post2-cp310-abi3-manylinux2014_aarch64.whl#sha256=c3080ac21e69b57e96961eeb6dec61cbfe66e95967447368e7e80addd34aeda5">sgl_kernel-0.3.9.post2-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.10/sgl_kernel-0.3.10+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=62dce4e4d8d669a29dbc9cb667b43558a40ac3bfc9ca59e5699fdd6920481956">sgl_kernel-0.3.10+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.10/sgl_kernel-0.3.10+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=f18c766e12bae623b8a09961707cf398c59bbc88ede9bfeaf6c61f61f30075ab">sgl_kernel-0.3.10+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.10/sgl_kernel-0.3.10-cp310-abi3-manylinux2014_aarch64.whl#sha256=1f59ac621fb8ef88fd1cef6a12b55df863e3362e630946f456493a44f1f9d136">sgl_kernel-0.3.10-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.11/sgl_kernel-0.3.11+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=add3297874df45bffd08fffad761b7a6418a91dba330d91fa42952b6e51d4244">sgl_kernel-0.3.11+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.11/sgl_kernel-0.3.11+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=e773fe2245c3d0fd447f9e9b8bfc991dd4ba7d65c52ef53f1d5ca5f80ec0e6d8">sgl_kernel-0.3.11+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.11/sgl_kernel-0.3.11-cp310-abi3-manylinux2014_aarch64.whl#sha256=3dd6e9e2c66d5fac5083b9ef15a2633ad0469bd380954e8a304a2e37bf03f0bc">sgl_kernel-0.3.11-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.12/sgl_kernel-0.3.12+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=befe15f9a154738e72204bd1efcf3d11e11204c4e9519878700cd5fe41573614">sgl_kernel-0.3.12+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.12/sgl_kernel-0.3.12+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=c47b2205b709710d47f4fae4ea08e348a43c9f6d62e40b2a6e2091bf29f5a308">sgl_kernel-0.3.12+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.12/sgl_kernel-0.3.12-cp310-abi3-manylinux2014_aarch64.whl#sha256=d070becb9d432a4077d9af9cca10f43759436211ac82b58bf94840b2f187b86c">sgl_kernel-0.3.12-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.13/sgl_kernel-0.3.13+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=585f7d170c21a7eeba829323366e8f1553a33a0595c1b008907752cbaf175ebd">sgl_kernel-0.3.13+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.13/sgl_kernel-0.3.13-cp310-abi3-manylinux2014_aarch64.whl#sha256=c248ca28b91d5d1a64416129276092105b47f2b5819d56d56b8da6902109a68c">sgl_kernel-0.3.13-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.14/sgl_kernel-0.3.14+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=401b0217614cd5b866ba8e47834881d5cb936baede80b8a25b86b7dd97970f13">sgl_kernel-0.3.14+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.14/sgl_kernel-0.3.14-cp310-abi3-manylinux2014_aarch64.whl#sha256=9360439a0c7edd335bd841464d8c3c4e95f5133d80af17b8d6b5ffaa75c512be">sgl_kernel-0.3.14-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.14.post1/sgl_kernel-0.3.14.post1+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=83f4372b9564d60e734a8601eba5864413f80851557d1833aeed73897c16d887">sgl_kernel-0.3.14.post1+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.14.post1/sgl_kernel-0.3.14.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=d799e3df31a782320ab5a9cd4a94d1fd962aace3cf9aa565dfd449009786db7c">sgl_kernel-0.3.14.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.14.post1/sgl_kernel-0.3.14.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=6aa383d27e731cd3b49b63ff8d05f75556ca8cdf1697c99668d835155515dc53">sgl_kernel-0.3.14.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.15/sgl_kernel-0.3.15-cp310-abi3-manylinux2014_x86_64.whl#sha256=3f1745a899af5d69355367859d13615e72fa8294750629913de56507c073aa43">sgl_kernel-0.3.15-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.15/sgl_kernel-0.3.15-cp310-abi3-manylinux2014_aarch64.whl#sha256=f6e7e1b39fd26e85f8e8b17c00b92b51b0cf591e61f78d0e1621737553a6f2a7">sgl_kernel-0.3.15-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.15/sgl_kernel-0.3.15-cp310-abi3-manylinux2014_x86_64.whl#sha256=3f1745a899af5d69355367859d13615e72fa8294750629913de56507c073aa43">sgl_kernel-0.3.15-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16/sgl_kernel-0.3.16-cp310-abi3-manylinux2014_aarch64.whl#sha256=4d53f3fca04c2bf52775ae5292d2dcc329a75876534433d85378c17d333675d3">sgl_kernel-0.3.16-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16/sgl_kernel-0.3.16-cp310-abi3-manylinux2014_aarch64.whl#sha256=4d53f3fca04c2bf52775ae5292d2dcc329a75876534433d85378c17d333675d3">sgl_kernel-0.3.16-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16/sgl_kernel-0.3.16-cp310-abi3-manylinux2014_x86_64.whl#sha256=a34f7e60952c3435dd3e79d9e9723d394e3a2493282a52b0c552e1b531225f3c">sgl_kernel-0.3.16-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post1/sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=4e4f697f5d01ca8973a7229d989dd4a9d4a21353fc62c66d1080fced31e59980">sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post1/sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=96dd0f0b348ea616d29f5c1ab38f6134766f3c37be2922e1f0a3de4229d161b8">sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post1/sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=4e4f697f5d01ca8973a7229d989dd4a9d4a21353fc62c66d1080fced31e59980">sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post2/sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_x86_64.whl#sha256=3dd529aeac9b6b7bc98be0b1f24c964eab376b4c764aa6220615c3574b27f826">sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post2/sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_aarch64.whl#sha256=907421ab56d51f1be66a9f7a13f0a397e93080314911774f34063f851782680f">sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post2/sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_x86_64.whl#sha256=3dd529aeac9b6b7bc98be0b1f24c964eab376b4c764aa6220615c3574b27f826">sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post3/sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_x86_64.whl#sha256=d12f1250233e2716db1b5096cfc4eb9ac1bfe6391ae4e40762be73210159bdf0">sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post3/sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_aarch64.whl#sha256=f144d83b6f3dd490ae6a89385ac72ef0857a1d9b0e6d59a516d485029cf4e571">sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post3/sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_x86_64.whl#sha256=d12f1250233e2716db1b5096cfc4eb9ac1bfe6391ae4e40762be73210159bdf0">sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post4/sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_aarch64.whl#sha256=d070f0206227c04294a15e4e081b935594bdfb9e8dad5a893bde02ce568a1fc9">sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post4/sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_x86_64.whl#sha256=12ffce253873df2433ed3df02b2a45f04e49d13edc3d965d284c2186ba291e5c">sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post5/sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_aarch64.whl#sha256=ecaf7b8f1e22b82c873c7bed43e7f18d612d683652a31a8f7df483c752d35ffb">sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post5/sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_x86_64.whl#sha256=3a81ecd6398ec0878f0992bbc7fe9434627cd93d8240808d396c2385f8021c8f">sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post6/sgl_kernel-0.3.16.post6-cp310-abi3-manylinux2014_aarch64.whl#sha256=07cf069698e7570ff4c740fdfdc620c09697ad8bf480815e7c490a1924599c5e">sgl_kernel-0.3.16.post6-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post6/sgl_kernel-0.3.16.post6-cp310-abi3-manylinux2014_x86_64.whl#sha256=78e58824a0d7280dec7b4d9a6db79435930227b2cb41ed92343a02b41d32ec63">sgl_kernel-0.3.16.post6-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.17/sgl_kernel-0.3.17-cp310-abi3-manylinux2014_aarch64.whl#sha256=688401e2bb16c2ca5d4e1433d5e8851ab9a77dd5dac99983e99b3e748a2916f0">sgl_kernel-0.3.17-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.17/sgl_kernel-0.3.17-cp310-abi3-manylinux2014_x86_64.whl#sha256=255af7d14a671059e5faebf3d897e08d2e522bdc04549d2205b9dd9844ebad29">sgl_kernel-0.3.17-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post1/sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=330057ad2d239e9363ee9abd85ed445ee1795161c60b7357f9792103121039cc">sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post1/sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=c864e6d6eebcd91e59a71ba781739761a21774f0cb862578381f54f504f93b4a">sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post1/sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=9f9c16d9a66c37660135065f0cebab2a7c28273111ea934c62fa4fa3ef3011a2">sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post1/sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=864f3d93dfc6a0adbb6bc07fcdad0daf7cd714be671829a87296e57d88331e25">sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post2/sgl_kernel-0.3.17.post2-cp310-abi3-manylinux2014_aarch64.whl#sha256=19a0b7bfa1d0e172998ba2efd0485aa899ede304388c4df84be7223e0d787478">sgl_kernel-0.3.17.post2-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post2/sgl_kernel-0.3.17.post2-cp310-abi3-manylinux2014_x86_64.whl#sha256=4e534863487a2484fa452de118478503a9f471f6d952b0c5616c9b980adef548">sgl_kernel-0.3.17.post2-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.18/sgl_kernel-0.3.18-cp310-abi3-manylinux2014_aarch64.whl#sha256=5b137b890b8110dbe4500d505b0436eadaf3e1a1f3c986711c581f5a19ec7bb1">sgl_kernel-0.3.18-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.18/sgl_kernel-0.3.18-cp310-abi3-manylinux2014_x86_64.whl#sha256=27790bf729a496750433753de6d38b82117b126b4919124649c9b8a4169b6617">sgl_kernel-0.3.18-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post1/sgl_kernel-0.3.18.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=df0052154ab3952b3500dc753260c7f05f890e3e6eaa4e5fc9f77884378db68e">sgl_kernel-0.3.18.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post1/sgl_kernel-0.3.18.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=0e6fabb2709b951afd75b4f9ffe2d5faaa6ca2dcbaf8f93855770807cf4f924b">sgl_kernel-0.3.18.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post2/sgl_kernel-0.3.18.post2-cp310-abi3-manylinux2014_aarch64.whl#sha256=c313d9393035f2c8e466eb51013e1254648fa8187206de6b3258e64b26e55161">sgl_kernel-0.3.18.post2-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post2/sgl_kernel-0.3.18.post2-cp310-abi3-manylinux2014_x86_64.whl#sha256=15eb39084139f1901ec5d24e9ff46ad87b5f98f8a42399237662ada5de7e5774">sgl_kernel-0.3.18.post2-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post3/sgl_kernel-0.3.18.post3-cp310-abi3-manylinux2014_aarch64.whl#sha256=957a8cc3c6adf7f8ae543eda1c00452e095706f961c01cbeb60da28d40b63c07">sgl_kernel-0.3.18.post3-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post3/sgl_kernel-0.3.18.post3-cp310-abi3-manylinux2014_x86_64.whl#sha256=5b34cf189a320e194e018aebcbae5230b615db61e68106932c2e95181c8299f1">sgl_kernel-0.3.18.post3-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.19/sgl_kernel-0.3.19-cp310-abi3-manylinux2014_aarch64.whl#sha256=db09851871c41416930e382f7d3a12b94705637891d2ec85dae56262abe26482">sgl_kernel-0.3.19-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.19/sgl_kernel-0.3.19-cp310-abi3-manylinux2014_x86_64.whl#sha256=477e123f272f18de6641e23175c63749f32e9d792ea53d52b9ade30238877b61">sgl_kernel-0.3.19-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl#sha256=d9f65e015b4b8fb163c05d8a549a9cf9058e6346380ed8dc184e951a9af95581">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl#sha256=f283c94e936bb24ef01700cd49ee8f1edee3e13b84ba9a268e2b9ae6dbb93924">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl#sha256=75d7337e90fdfe2517abebd6cb87e4cb4710fb814e6e6e9bcf541b7843f742c7">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl#sha256=2441382167205b7586ea6c253969fa87b58124256fe55ef27251a2c5d67739cc">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl#sha256=8ecfe783908f823d91f344ad4c0b68b40bae7f540795337189cc1c7dd993b345">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl#sha256=f3133def78d9811c13407fcbc0b3fdf714b89eafd4e90b87d389b2d60173fbc9">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.21/sgl_kernel-0.3.21-cp310-abi3-manylinux2014_aarch64.whl#sha256=bafdcc26e9ce1e9102b99e4186d652fefbafe5c22ea2cbb5ffe07b331e83be1f">sgl_kernel-0.3.21-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a
-    href="https://github.com/sgl-project/whl/releases/download/v0.3.21/sgl_kernel-0.3.21-cp310-abi3-manylinux2014_x86_64.whl#sha256=e7f66eb6a149ae2d1ea5a5bc29bc14cbb4322a23952d8d861eedbb253850c90f">sgl_kernel-0.3.21-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.3/sgl_kernel-0.3.3-cp39-abi3-manylinux2014_x86_64.whl#sha256=6baa35a48e3f3d0ac9e764d19e9706c5fca2ed1b2b6d21327d930bccbf15812f">sgl_kernel-0.3.3-cp39-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.4/sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=8c1093880a90c9768c4419e1bbc8cb9788296432b498c38f41844796fe2b3dac">sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.4/sgl_kernel-0.3.4+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=0241d5bfbf6cc6117c6366941f2ec4e777ea4ad5df1a44342b00c1f812642c0a">sgl_kernel-0.3.4+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.4/sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=f95cd55d3da3a2f5f4bde6950f14c0f342ee888f7fecb58e366d34003365b346">sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.4/sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=8c1093880a90c9768c4419e1bbc8cb9788296432b498c38f41844796fe2b3dac">sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.4.post1/sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=3ec5dac4da6edff73e6225435034aee92b469c51c4a69137786329c57b72ca59">sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.4.post1/sgl_kernel-0.3.4.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=3ac1df6283976723afe3f5daa2d6e4ea1d3ac23850b397dd5612a2fc986face0">sgl_kernel-0.3.4.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.4.post1/sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=9218d6107cb5bda1c15b2657ced4a75bfddf680c1a4b4821121d760f776bceed">sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.4.post1/sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=3ec5dac4da6edff73e6225435034aee92b469c51c4a69137786329c57b72ca59">sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.5/sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=861652872549a802b72922fc995ff2a58901db6d8d34fabe68fe00ef939fd768">sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.5/sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=3a602ac4a545ef4c5b2804680fcdf29d7468eae49f4dcc00e765f6d2932d1860">sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.5/sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=861652872549a802b72922fc995ff2a58901db6d8d34fabe68fe00ef939fd768">sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.6/sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=c63d740a63ee944f6e5bff15546515576565a2fea1cdddb99bcdea293ff2b028">sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.6/sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=c63d740a63ee944f6e5bff15546515576565a2fea1cdddb99bcdea293ff2b028">sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.6/sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=42abd39be44154d34298d7f2ad142dda74f945a0cf0340b99bef90b9a5358ff1">sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.6.post1/sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=8638121325827576e8996e009297efa4f59d7fbcc00324ad217f05886db7a3f7">sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.6.post1/sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=f934b46d65f7e9788e31f0b029e03b02da7971c3f1944779fe3f36eba561c2f9">sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.6.post1/sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=8638121325827576e8996e009297efa4f59d7fbcc00324ad217f05886db7a3f7">sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.6.post2/sgl_kernel-0.3.6.post2+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=6bdde60513ccfd2d7e590ceebaca66b72455b3f5e53ce5b5e7eae4ccda88ed26">sgl_kernel-0.3.6.post2+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.7/sgl_kernel-0.3.7+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=da4665c036f8ec4ed3079326022ee24f3a72dc90bd3d71e4d68762f570fc5a3d">sgl_kernel-0.3.7+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.7.post1/sgl_kernel-0.3.7.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=e3638db21650e15a8577eccbef851d808f6ac0ed9d7fed9c28cd4c6756bb52ec">sgl_kernel-0.3.7.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.8/sgl_kernel-0.3.8+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=bafefcfe2ef1d303fcca7d48fff13ab307b62ccb9f19a4ffc4c21d5128c61a8b">sgl_kernel-0.3.8+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9/sgl_kernel-0.3.9+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=30ccbe21a0665e8887ef65a0993e80c74a963fb021cf67b85a62e6e6aa207b03">sgl_kernel-0.3.9+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9/sgl_kernel-0.3.9+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=1612c6af52db870260cb9042edcad1c67e3d07fcce6e65bc4b85c290377dfada">sgl_kernel-0.3.9+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9/sgl_kernel-0.3.9-cp310-abi3-manylinux2014_aarch64.whl#sha256=e4d623154e81b5e47e9ad0ad8ad5509f0255c8826205e62f097a52193eb7675f">sgl_kernel-0.3.9-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post1/sgl_kernel-0.3.9.post1+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=34520cfdf08d97ea9bdd5edcad4a6b317b79a67c073d3a44f5a8f52da83c3ebe">sgl_kernel-0.3.9.post1+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post1/sgl_kernel-0.3.9.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=e26d05487c23e76e08804c05531fa76e52b058a7b71e427c0152b825f71bd6a4">sgl_kernel-0.3.9.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post1/sgl_kernel-0.3.9.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=1d11eea249f38fa6ec151460d805ba0240f382262195d22d0419ad7b8b17278b">sgl_kernel-0.3.9.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post2/sgl_kernel-0.3.9.post2+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=357eb2a4de102332460bddca26b5b0f982b850e9af0a49c9f7677018e3c3583c">sgl_kernel-0.3.9.post2+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post2/sgl_kernel-0.3.9.post2+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=efcd8b29773583829021a1380213cc826967a2562242cbefba4f0c36ee18bf8c">sgl_kernel-0.3.9.post2+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post2/sgl_kernel-0.3.9.post2-cp310-abi3-manylinux2014_aarch64.whl#sha256=c3080ac21e69b57e96961eeb6dec61cbfe66e95967447368e7e80addd34aeda5">sgl_kernel-0.3.9.post2-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.10/sgl_kernel-0.3.10+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=62dce4e4d8d669a29dbc9cb667b43558a40ac3bfc9ca59e5699fdd6920481956">sgl_kernel-0.3.10+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.10/sgl_kernel-0.3.10+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=f18c766e12bae623b8a09961707cf398c59bbc88ede9bfeaf6c61f61f30075ab">sgl_kernel-0.3.10+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.10/sgl_kernel-0.3.10-cp310-abi3-manylinux2014_aarch64.whl#sha256=1f59ac621fb8ef88fd1cef6a12b55df863e3362e630946f456493a44f1f9d136">sgl_kernel-0.3.10-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.11/sgl_kernel-0.3.11+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=add3297874df45bffd08fffad761b7a6418a91dba330d91fa42952b6e51d4244">sgl_kernel-0.3.11+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.11/sgl_kernel-0.3.11+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=e773fe2245c3d0fd447f9e9b8bfc991dd4ba7d65c52ef53f1d5ca5f80ec0e6d8">sgl_kernel-0.3.11+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.11/sgl_kernel-0.3.11-cp310-abi3-manylinux2014_aarch64.whl#sha256=3dd6e9e2c66d5fac5083b9ef15a2633ad0469bd380954e8a304a2e37bf03f0bc">sgl_kernel-0.3.11-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.12/sgl_kernel-0.3.12+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=befe15f9a154738e72204bd1efcf3d11e11204c4e9519878700cd5fe41573614">sgl_kernel-0.3.12+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.12/sgl_kernel-0.3.12+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=c47b2205b709710d47f4fae4ea08e348a43c9f6d62e40b2a6e2091bf29f5a308">sgl_kernel-0.3.12+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.12/sgl_kernel-0.3.12-cp310-abi3-manylinux2014_aarch64.whl#sha256=d070becb9d432a4077d9af9cca10f43759436211ac82b58bf94840b2f187b86c">sgl_kernel-0.3.12-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.13/sgl_kernel-0.3.13+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=585f7d170c21a7eeba829323366e8f1553a33a0595c1b008907752cbaf175ebd">sgl_kernel-0.3.13+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.13/sgl_kernel-0.3.13-cp310-abi3-manylinux2014_aarch64.whl#sha256=c248ca28b91d5d1a64416129276092105b47f2b5819d56d56b8da6902109a68c">sgl_kernel-0.3.13-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.14/sgl_kernel-0.3.14+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=401b0217614cd5b866ba8e47834881d5cb936baede80b8a25b86b7dd97970f13">sgl_kernel-0.3.14+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.14/sgl_kernel-0.3.14-cp310-abi3-manylinux2014_aarch64.whl#sha256=9360439a0c7edd335bd841464d8c3c4e95f5133d80af17b8d6b5ffaa75c512be">sgl_kernel-0.3.14-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.14.post1/sgl_kernel-0.3.14.post1+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=83f4372b9564d60e734a8601eba5864413f80851557d1833aeed73897c16d887">sgl_kernel-0.3.14.post1+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.14.post1/sgl_kernel-0.3.14.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=d799e3df31a782320ab5a9cd4a94d1fd962aace3cf9aa565dfd449009786db7c">sgl_kernel-0.3.14.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.14.post1/sgl_kernel-0.3.14.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=6aa383d27e731cd3b49b63ff8d05f75556ca8cdf1697c99668d835155515dc53">sgl_kernel-0.3.14.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.15/sgl_kernel-0.3.15-cp310-abi3-manylinux2014_x86_64.whl#sha256=3f1745a899af5d69355367859d13615e72fa8294750629913de56507c073aa43">sgl_kernel-0.3.15-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.15/sgl_kernel-0.3.15-cp310-abi3-manylinux2014_aarch64.whl#sha256=f6e7e1b39fd26e85f8e8b17c00b92b51b0cf591e61f78d0e1621737553a6f2a7">sgl_kernel-0.3.15-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.15/sgl_kernel-0.3.15-cp310-abi3-manylinux2014_x86_64.whl#sha256=3f1745a899af5d69355367859d13615e72fa8294750629913de56507c073aa43">sgl_kernel-0.3.15-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16/sgl_kernel-0.3.16-cp310-abi3-manylinux2014_aarch64.whl#sha256=4d53f3fca04c2bf52775ae5292d2dcc329a75876534433d85378c17d333675d3">sgl_kernel-0.3.16-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16/sgl_kernel-0.3.16-cp310-abi3-manylinux2014_aarch64.whl#sha256=4d53f3fca04c2bf52775ae5292d2dcc329a75876534433d85378c17d333675d3">sgl_kernel-0.3.16-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16/sgl_kernel-0.3.16-cp310-abi3-manylinux2014_x86_64.whl#sha256=a34f7e60952c3435dd3e79d9e9723d394e3a2493282a52b0c552e1b531225f3c">sgl_kernel-0.3.16-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post1/sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=4e4f697f5d01ca8973a7229d989dd4a9d4a21353fc62c66d1080fced31e59980">sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post1/sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=96dd0f0b348ea616d29f5c1ab38f6134766f3c37be2922e1f0a3de4229d161b8">sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post1/sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=4e4f697f5d01ca8973a7229d989dd4a9d4a21353fc62c66d1080fced31e59980">sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post2/sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_x86_64.whl#sha256=3dd529aeac9b6b7bc98be0b1f24c964eab376b4c764aa6220615c3574b27f826">sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post2/sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_aarch64.whl#sha256=907421ab56d51f1be66a9f7a13f0a397e93080314911774f34063f851782680f">sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post2/sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_x86_64.whl#sha256=3dd529aeac9b6b7bc98be0b1f24c964eab376b4c764aa6220615c3574b27f826">sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post3/sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_x86_64.whl#sha256=d12f1250233e2716db1b5096cfc4eb9ac1bfe6391ae4e40762be73210159bdf0">sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post3/sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_aarch64.whl#sha256=f144d83b6f3dd490ae6a89385ac72ef0857a1d9b0e6d59a516d485029cf4e571">sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post3/sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_x86_64.whl#sha256=d12f1250233e2716db1b5096cfc4eb9ac1bfe6391ae4e40762be73210159bdf0">sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post4/sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_aarch64.whl#sha256=d070f0206227c04294a15e4e081b935594bdfb9e8dad5a893bde02ce568a1fc9">sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post4/sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_x86_64.whl#sha256=12ffce253873df2433ed3df02b2a45f04e49d13edc3d965d284c2186ba291e5c">sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post5/sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_aarch64.whl#sha256=ecaf7b8f1e22b82c873c7bed43e7f18d612d683652a31a8f7df483c752d35ffb">sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post5/sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_x86_64.whl#sha256=3a81ecd6398ec0878f0992bbc7fe9434627cd93d8240808d396c2385f8021c8f">sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post6/sgl_kernel-0.3.16.post6-cp310-abi3-manylinux2014_aarch64.whl#sha256=07cf069698e7570ff4c740fdfdc620c09697ad8bf480815e7c490a1924599c5e">sgl_kernel-0.3.16.post6-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post6/sgl_kernel-0.3.16.post6-cp310-abi3-manylinux2014_x86_64.whl#sha256=78e58824a0d7280dec7b4d9a6db79435930227b2cb41ed92343a02b41d32ec63">sgl_kernel-0.3.16.post6-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.17/sgl_kernel-0.3.17-cp310-abi3-manylinux2014_aarch64.whl#sha256=688401e2bb16c2ca5d4e1433d5e8851ab9a77dd5dac99983e99b3e748a2916f0">sgl_kernel-0.3.17-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.17/sgl_kernel-0.3.17-cp310-abi3-manylinux2014_x86_64.whl#sha256=255af7d14a671059e5faebf3d897e08d2e522bdc04549d2205b9dd9844ebad29">sgl_kernel-0.3.17-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post1/sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=330057ad2d239e9363ee9abd85ed445ee1795161c60b7357f9792103121039cc">sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post1/sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=c864e6d6eebcd91e59a71ba781739761a21774f0cb862578381f54f504f93b4a">sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post1/sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=9f9c16d9a66c37660135065f0cebab2a7c28273111ea934c62fa4fa3ef3011a2">sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post1/sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=864f3d93dfc6a0adbb6bc07fcdad0daf7cd714be671829a87296e57d88331e25">sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post2/sgl_kernel-0.3.17.post2-cp310-abi3-manylinux2014_aarch64.whl#sha256=19a0b7bfa1d0e172998ba2efd0485aa899ede304388c4df84be7223e0d787478">sgl_kernel-0.3.17.post2-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post2/sgl_kernel-0.3.17.post2-cp310-abi3-manylinux2014_x86_64.whl#sha256=4e534863487a2484fa452de118478503a9f471f6d952b0c5616c9b980adef548">sgl_kernel-0.3.17.post2-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.18/sgl_kernel-0.3.18-cp310-abi3-manylinux2014_aarch64.whl#sha256=5b137b890b8110dbe4500d505b0436eadaf3e1a1f3c986711c581f5a19ec7bb1">sgl_kernel-0.3.18-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.18/sgl_kernel-0.3.18-cp310-abi3-manylinux2014_x86_64.whl#sha256=27790bf729a496750433753de6d38b82117b126b4919124649c9b8a4169b6617">sgl_kernel-0.3.18-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post1/sgl_kernel-0.3.18.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=df0052154ab3952b3500dc753260c7f05f890e3e6eaa4e5fc9f77884378db68e">sgl_kernel-0.3.18.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post1/sgl_kernel-0.3.18.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=0e6fabb2709b951afd75b4f9ffe2d5faaa6ca2dcbaf8f93855770807cf4f924b">sgl_kernel-0.3.18.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post2/sgl_kernel-0.3.18.post2-cp310-abi3-manylinux2014_aarch64.whl#sha256=c313d9393035f2c8e466eb51013e1254648fa8187206de6b3258e64b26e55161">sgl_kernel-0.3.18.post2-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post2/sgl_kernel-0.3.18.post2-cp310-abi3-manylinux2014_x86_64.whl#sha256=15eb39084139f1901ec5d24e9ff46ad87b5f98f8a42399237662ada5de7e5774">sgl_kernel-0.3.18.post2-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post3/sgl_kernel-0.3.18.post3-cp310-abi3-manylinux2014_aarch64.whl#sha256=957a8cc3c6adf7f8ae543eda1c00452e095706f961c01cbeb60da28d40b63c07">sgl_kernel-0.3.18.post3-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post3/sgl_kernel-0.3.18.post3-cp310-abi3-manylinux2014_x86_64.whl#sha256=5b34cf189a320e194e018aebcbae5230b615db61e68106932c2e95181c8299f1">sgl_kernel-0.3.18.post3-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.19/sgl_kernel-0.3.19-cp310-abi3-manylinux2014_aarch64.whl#sha256=db09851871c41416930e382f7d3a12b94705637891d2ec85dae56262abe26482">sgl_kernel-0.3.19-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.19/sgl_kernel-0.3.19-cp310-abi3-manylinux2014_x86_64.whl#sha256=477e123f272f18de6641e23175c63749f32e9d792ea53d52b9ade30238877b61">sgl_kernel-0.3.19-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl#sha256=d9f65e015b4b8fb163c05d8a549a9cf9058e6346380ed8dc184e951a9af95581">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl#sha256=f283c94e936bb24ef01700cd49ee8f1edee3e13b84ba9a268e2b9ae6dbb93924">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl#sha256=75d7337e90fdfe2517abebd6cb87e4cb4710fb814e6e6e9bcf541b7843f742c7">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl#sha256=2441382167205b7586ea6c253969fa87b58124256fe55ef27251a2c5d67739cc">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl#sha256=8ecfe783908f823d91f344ad4c0b68b40bae7f540795337189cc1c7dd993b345">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl#sha256=f3133def78d9811c13407fcbc0b3fdf714b89eafd4e90b87d389b2d60173fbc9">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.21/sgl_kernel-0.3.21-cp310-abi3-manylinux2014_aarch64.whl#sha256=bafdcc26e9ce1e9102b99e4186d652fefbafe5c22ea2cbb5ffe07b331e83be1f">sgl_kernel-0.3.21-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a href="https://github.com/sgl-project/whl/releases/download/v0.3.21/sgl_kernel-0.3.21-cp310-abi3-manylinux2014_x86_64.whl#sha256=e7f66eb6a149ae2d1ea5a5bc29bc14cbb4322a23952d8d861eedbb253850c90f">sgl_kernel-0.3.21-cp310-abi3-manylinux2014_x86_64.whl</a><br>

--- a/cu129/sgl-kernel/index.html
+++ b/cu129/sgl-kernel/index.html
@@ -1,96 +1,190 @@
 <!DOCTYPE html>
 <h1>SGLang Kernel Library Wheels for CUDA 12.9</h1>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.3/sgl_kernel-0.3.3-cp39-abi3-manylinux2014_x86_64.whl#sha256=6baa35a48e3f3d0ac9e764d19e9706c5fca2ed1b2b6d21327d930bccbf15812f">sgl_kernel-0.3.3-cp39-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.4/sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=8c1093880a90c9768c4419e1bbc8cb9788296432b498c38f41844796fe2b3dac">sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.4/sgl_kernel-0.3.4+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=0241d5bfbf6cc6117c6366941f2ec4e777ea4ad5df1a44342b00c1f812642c0a">sgl_kernel-0.3.4+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.4/sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=f95cd55d3da3a2f5f4bde6950f14c0f342ee888f7fecb58e366d34003365b346">sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.4/sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=8c1093880a90c9768c4419e1bbc8cb9788296432b498c38f41844796fe2b3dac">sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.4.post1/sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=3ec5dac4da6edff73e6225435034aee92b469c51c4a69137786329c57b72ca59">sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.4.post1/sgl_kernel-0.3.4.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=3ac1df6283976723afe3f5daa2d6e4ea1d3ac23850b397dd5612a2fc986face0">sgl_kernel-0.3.4.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.4.post1/sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=9218d6107cb5bda1c15b2657ced4a75bfddf680c1a4b4821121d760f776bceed">sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.4.post1/sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=3ec5dac4da6edff73e6225435034aee92b469c51c4a69137786329c57b72ca59">sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.5/sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=861652872549a802b72922fc995ff2a58901db6d8d34fabe68fe00ef939fd768">sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.5/sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=3a602ac4a545ef4c5b2804680fcdf29d7468eae49f4dcc00e765f6d2932d1860">sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.5/sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=861652872549a802b72922fc995ff2a58901db6d8d34fabe68fe00ef939fd768">sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.6/sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=c63d740a63ee944f6e5bff15546515576565a2fea1cdddb99bcdea293ff2b028">sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.6/sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=c63d740a63ee944f6e5bff15546515576565a2fea1cdddb99bcdea293ff2b028">sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.6/sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=42abd39be44154d34298d7f2ad142dda74f945a0cf0340b99bef90b9a5358ff1">sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.6.post1/sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=8638121325827576e8996e009297efa4f59d7fbcc00324ad217f05886db7a3f7">sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.6.post1/sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=f934b46d65f7e9788e31f0b029e03b02da7971c3f1944779fe3f36eba561c2f9">sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.6.post1/sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=8638121325827576e8996e009297efa4f59d7fbcc00324ad217f05886db7a3f7">sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.6.post2/sgl_kernel-0.3.6.post2+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=6bdde60513ccfd2d7e590ceebaca66b72455b3f5e53ce5b5e7eae4ccda88ed26">sgl_kernel-0.3.6.post2+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.7/sgl_kernel-0.3.7+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=da4665c036f8ec4ed3079326022ee24f3a72dc90bd3d71e4d68762f570fc5a3d">sgl_kernel-0.3.7+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.7.post1/sgl_kernel-0.3.7.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=e3638db21650e15a8577eccbef851d808f6ac0ed9d7fed9c28cd4c6756bb52ec">sgl_kernel-0.3.7.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.8/sgl_kernel-0.3.8+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=bafefcfe2ef1d303fcca7d48fff13ab307b62ccb9f19a4ffc4c21d5128c61a8b">sgl_kernel-0.3.8+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9/sgl_kernel-0.3.9+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=30ccbe21a0665e8887ef65a0993e80c74a963fb021cf67b85a62e6e6aa207b03">sgl_kernel-0.3.9+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9/sgl_kernel-0.3.9+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=1612c6af52db870260cb9042edcad1c67e3d07fcce6e65bc4b85c290377dfada">sgl_kernel-0.3.9+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9/sgl_kernel-0.3.9-cp310-abi3-manylinux2014_aarch64.whl#sha256=e4d623154e81b5e47e9ad0ad8ad5509f0255c8826205e62f097a52193eb7675f">sgl_kernel-0.3.9-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post1/sgl_kernel-0.3.9.post1+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=34520cfdf08d97ea9bdd5edcad4a6b317b79a67c073d3a44f5a8f52da83c3ebe">sgl_kernel-0.3.9.post1+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post1/sgl_kernel-0.3.9.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=e26d05487c23e76e08804c05531fa76e52b058a7b71e427c0152b825f71bd6a4">sgl_kernel-0.3.9.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post1/sgl_kernel-0.3.9.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=1d11eea249f38fa6ec151460d805ba0240f382262195d22d0419ad7b8b17278b">sgl_kernel-0.3.9.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post2/sgl_kernel-0.3.9.post2+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=357eb2a4de102332460bddca26b5b0f982b850e9af0a49c9f7677018e3c3583c">sgl_kernel-0.3.9.post2+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post2/sgl_kernel-0.3.9.post2+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=efcd8b29773583829021a1380213cc826967a2562242cbefba4f0c36ee18bf8c">sgl_kernel-0.3.9.post2+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post2/sgl_kernel-0.3.9.post2-cp310-abi3-manylinux2014_aarch64.whl#sha256=c3080ac21e69b57e96961eeb6dec61cbfe66e95967447368e7e80addd34aeda5">sgl_kernel-0.3.9.post2-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.10/sgl_kernel-0.3.10+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=62dce4e4d8d669a29dbc9cb667b43558a40ac3bfc9ca59e5699fdd6920481956">sgl_kernel-0.3.10+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.10/sgl_kernel-0.3.10+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=f18c766e12bae623b8a09961707cf398c59bbc88ede9bfeaf6c61f61f30075ab">sgl_kernel-0.3.10+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.10/sgl_kernel-0.3.10-cp310-abi3-manylinux2014_aarch64.whl#sha256=1f59ac621fb8ef88fd1cef6a12b55df863e3362e630946f456493a44f1f9d136">sgl_kernel-0.3.10-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.11/sgl_kernel-0.3.11+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=add3297874df45bffd08fffad761b7a6418a91dba330d91fa42952b6e51d4244">sgl_kernel-0.3.11+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.11/sgl_kernel-0.3.11+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=e773fe2245c3d0fd447f9e9b8bfc991dd4ba7d65c52ef53f1d5ca5f80ec0e6d8">sgl_kernel-0.3.11+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.11/sgl_kernel-0.3.11-cp310-abi3-manylinux2014_aarch64.whl#sha256=3dd6e9e2c66d5fac5083b9ef15a2633ad0469bd380954e8a304a2e37bf03f0bc">sgl_kernel-0.3.11-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.12/sgl_kernel-0.3.12+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=befe15f9a154738e72204bd1efcf3d11e11204c4e9519878700cd5fe41573614">sgl_kernel-0.3.12+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.12/sgl_kernel-0.3.12+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=c47b2205b709710d47f4fae4ea08e348a43c9f6d62e40b2a6e2091bf29f5a308">sgl_kernel-0.3.12+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.12/sgl_kernel-0.3.12-cp310-abi3-manylinux2014_aarch64.whl#sha256=d070becb9d432a4077d9af9cca10f43759436211ac82b58bf94840b2f187b86c">sgl_kernel-0.3.12-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.13/sgl_kernel-0.3.13+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=585f7d170c21a7eeba829323366e8f1553a33a0595c1b008907752cbaf175ebd">sgl_kernel-0.3.13+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.13/sgl_kernel-0.3.13-cp310-abi3-manylinux2014_aarch64.whl#sha256=c248ca28b91d5d1a64416129276092105b47f2b5819d56d56b8da6902109a68c">sgl_kernel-0.3.13-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.14/sgl_kernel-0.3.14+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=401b0217614cd5b866ba8e47834881d5cb936baede80b8a25b86b7dd97970f13">sgl_kernel-0.3.14+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.14/sgl_kernel-0.3.14-cp310-abi3-manylinux2014_aarch64.whl#sha256=9360439a0c7edd335bd841464d8c3c4e95f5133d80af17b8d6b5ffaa75c512be">sgl_kernel-0.3.14-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.14.post1/sgl_kernel-0.3.14.post1+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=83f4372b9564d60e734a8601eba5864413f80851557d1833aeed73897c16d887">sgl_kernel-0.3.14.post1+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.14.post1/sgl_kernel-0.3.14.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=d799e3df31a782320ab5a9cd4a94d1fd962aace3cf9aa565dfd449009786db7c">sgl_kernel-0.3.14.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.14.post1/sgl_kernel-0.3.14.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=6aa383d27e731cd3b49b63ff8d05f75556ca8cdf1697c99668d835155515dc53">sgl_kernel-0.3.14.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.15/sgl_kernel-0.3.15-cp310-abi3-manylinux2014_x86_64.whl#sha256=3f1745a899af5d69355367859d13615e72fa8294750629913de56507c073aa43">sgl_kernel-0.3.15-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.15/sgl_kernel-0.3.15-cp310-abi3-manylinux2014_aarch64.whl#sha256=f6e7e1b39fd26e85f8e8b17c00b92b51b0cf591e61f78d0e1621737553a6f2a7">sgl_kernel-0.3.15-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.15/sgl_kernel-0.3.15-cp310-abi3-manylinux2014_x86_64.whl#sha256=3f1745a899af5d69355367859d13615e72fa8294750629913de56507c073aa43">sgl_kernel-0.3.15-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16/sgl_kernel-0.3.16-cp310-abi3-manylinux2014_aarch64.whl#sha256=4d53f3fca04c2bf52775ae5292d2dcc329a75876534433d85378c17d333675d3">sgl_kernel-0.3.16-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16/sgl_kernel-0.3.16-cp310-abi3-manylinux2014_aarch64.whl#sha256=4d53f3fca04c2bf52775ae5292d2dcc329a75876534433d85378c17d333675d3">sgl_kernel-0.3.16-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16/sgl_kernel-0.3.16-cp310-abi3-manylinux2014_x86_64.whl#sha256=a34f7e60952c3435dd3e79d9e9723d394e3a2493282a52b0c552e1b531225f3c">sgl_kernel-0.3.16-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post1/sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=4e4f697f5d01ca8973a7229d989dd4a9d4a21353fc62c66d1080fced31e59980">sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post1/sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=96dd0f0b348ea616d29f5c1ab38f6134766f3c37be2922e1f0a3de4229d161b8">sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post1/sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=4e4f697f5d01ca8973a7229d989dd4a9d4a21353fc62c66d1080fced31e59980">sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post2/sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_x86_64.whl#sha256=3dd529aeac9b6b7bc98be0b1f24c964eab376b4c764aa6220615c3574b27f826">sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post2/sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_aarch64.whl#sha256=907421ab56d51f1be66a9f7a13f0a397e93080314911774f34063f851782680f">sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post2/sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_x86_64.whl#sha256=3dd529aeac9b6b7bc98be0b1f24c964eab376b4c764aa6220615c3574b27f826">sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post3/sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_x86_64.whl#sha256=d12f1250233e2716db1b5096cfc4eb9ac1bfe6391ae4e40762be73210159bdf0">sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post3/sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_aarch64.whl#sha256=f144d83b6f3dd490ae6a89385ac72ef0857a1d9b0e6d59a516d485029cf4e571">sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post3/sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_x86_64.whl#sha256=d12f1250233e2716db1b5096cfc4eb9ac1bfe6391ae4e40762be73210159bdf0">sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post4/sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_aarch64.whl#sha256=d070f0206227c04294a15e4e081b935594bdfb9e8dad5a893bde02ce568a1fc9">sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post4/sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_x86_64.whl#sha256=12ffce253873df2433ed3df02b2a45f04e49d13edc3d965d284c2186ba291e5c">sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post5/sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_aarch64.whl#sha256=ecaf7b8f1e22b82c873c7bed43e7f18d612d683652a31a8f7df483c752d35ffb">sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post5/sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_x86_64.whl#sha256=3a81ecd6398ec0878f0992bbc7fe9434627cd93d8240808d396c2385f8021c8f">sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post6/sgl_kernel-0.3.16.post6-cp310-abi3-manylinux2014_aarch64.whl#sha256=07cf069698e7570ff4c740fdfdc620c09697ad8bf480815e7c490a1924599c5e">sgl_kernel-0.3.16.post6-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post6/sgl_kernel-0.3.16.post6-cp310-abi3-manylinux2014_x86_64.whl#sha256=78e58824a0d7280dec7b4d9a6db79435930227b2cb41ed92343a02b41d32ec63">sgl_kernel-0.3.16.post6-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.17/sgl_kernel-0.3.17-cp310-abi3-manylinux2014_aarch64.whl#sha256=688401e2bb16c2ca5d4e1433d5e8851ab9a77dd5dac99983e99b3e748a2916f0">sgl_kernel-0.3.17-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.17/sgl_kernel-0.3.17-cp310-abi3-manylinux2014_x86_64.whl#sha256=255af7d14a671059e5faebf3d897e08d2e522bdc04549d2205b9dd9844ebad29">sgl_kernel-0.3.17-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post1/sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=330057ad2d239e9363ee9abd85ed445ee1795161c60b7357f9792103121039cc">sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post1/sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=c864e6d6eebcd91e59a71ba781739761a21774f0cb862578381f54f504f93b4a">sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post1/sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=9f9c16d9a66c37660135065f0cebab2a7c28273111ea934c62fa4fa3ef3011a2">sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post1/sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=864f3d93dfc6a0adbb6bc07fcdad0daf7cd714be671829a87296e57d88331e25">sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post2/sgl_kernel-0.3.17.post2-cp310-abi3-manylinux2014_aarch64.whl#sha256=19a0b7bfa1d0e172998ba2efd0485aa899ede304388c4df84be7223e0d787478">sgl_kernel-0.3.17.post2-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post2/sgl_kernel-0.3.17.post2-cp310-abi3-manylinux2014_x86_64.whl#sha256=4e534863487a2484fa452de118478503a9f471f6d952b0c5616c9b980adef548">sgl_kernel-0.3.17.post2-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.18/sgl_kernel-0.3.18-cp310-abi3-manylinux2014_aarch64.whl#sha256=5b137b890b8110dbe4500d505b0436eadaf3e1a1f3c986711c581f5a19ec7bb1">sgl_kernel-0.3.18-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.18/sgl_kernel-0.3.18-cp310-abi3-manylinux2014_x86_64.whl#sha256=27790bf729a496750433753de6d38b82117b126b4919124649c9b8a4169b6617">sgl_kernel-0.3.18-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post1/sgl_kernel-0.3.18.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=df0052154ab3952b3500dc753260c7f05f890e3e6eaa4e5fc9f77884378db68e">sgl_kernel-0.3.18.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post1/sgl_kernel-0.3.18.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=0e6fabb2709b951afd75b4f9ffe2d5faaa6ca2dcbaf8f93855770807cf4f924b">sgl_kernel-0.3.18.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post2/sgl_kernel-0.3.18.post2-cp310-abi3-manylinux2014_aarch64.whl#sha256=c313d9393035f2c8e466eb51013e1254648fa8187206de6b3258e64b26e55161">sgl_kernel-0.3.18.post2-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post2/sgl_kernel-0.3.18.post2-cp310-abi3-manylinux2014_x86_64.whl#sha256=15eb39084139f1901ec5d24e9ff46ad87b5f98f8a42399237662ada5de7e5774">sgl_kernel-0.3.18.post2-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post3/sgl_kernel-0.3.18.post3-cp310-abi3-manylinux2014_aarch64.whl#sha256=957a8cc3c6adf7f8ae543eda1c00452e095706f961c01cbeb60da28d40b63c07">sgl_kernel-0.3.18.post3-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post3/sgl_kernel-0.3.18.post3-cp310-abi3-manylinux2014_x86_64.whl#sha256=5b34cf189a320e194e018aebcbae5230b615db61e68106932c2e95181c8299f1">sgl_kernel-0.3.18.post3-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.19/sgl_kernel-0.3.19-cp310-abi3-manylinux2014_aarch64.whl#sha256=db09851871c41416930e382f7d3a12b94705637891d2ec85dae56262abe26482">sgl_kernel-0.3.19-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.19/sgl_kernel-0.3.19-cp310-abi3-manylinux2014_x86_64.whl#sha256=477e123f272f18de6641e23175c63749f32e9d792ea53d52b9ade30238877b61">sgl_kernel-0.3.19-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl#sha256=d9f65e015b4b8fb163c05d8a549a9cf9058e6346380ed8dc184e951a9af95581">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl#sha256=f283c94e936bb24ef01700cd49ee8f1edee3e13b84ba9a268e2b9ae6dbb93924">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl#sha256=75d7337e90fdfe2517abebd6cb87e4cb4710fb814e6e6e9bcf541b7843f742c7">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl#sha256=2441382167205b7586ea6c253969fa87b58124256fe55ef27251a2c5d67739cc">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl#sha256=8ecfe783908f823d91f344ad4c0b68b40bae7f540795337189cc1c7dd993b345">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl#sha256=f3133def78d9811c13407fcbc0b3fdf714b89eafd4e90b87d389b2d60173fbc9">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.21/sgl_kernel-0.3.21-cp310-abi3-manylinux2014_aarch64.whl#sha256=bafdcc26e9ce1e9102b99e4186d652fefbafe5c22ea2cbb5ffe07b331e83be1f">sgl_kernel-0.3.21-cp310-abi3-manylinux2014_aarch64.whl</a><br>
-<a href="https://github.com/sgl-project/whl/releases/download/v0.3.21/sgl_kernel-0.3.21-cp310-abi3-manylinux2014_x86_64.whl#sha256=57dfb3a2a3cd759f499c32e2bad5f6489b7c58f7f9a84ee00c53ec92d303aaab">sgl_kernel-0.3.21-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.3/sgl_kernel-0.3.3-cp39-abi3-manylinux2014_x86_64.whl#sha256=6baa35a48e3f3d0ac9e764d19e9706c5fca2ed1b2b6d21327d930bccbf15812f">sgl_kernel-0.3.3-cp39-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.4/sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=8c1093880a90c9768c4419e1bbc8cb9788296432b498c38f41844796fe2b3dac">sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.4/sgl_kernel-0.3.4+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=0241d5bfbf6cc6117c6366941f2ec4e777ea4ad5df1a44342b00c1f812642c0a">sgl_kernel-0.3.4+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.4/sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=f95cd55d3da3a2f5f4bde6950f14c0f342ee888f7fecb58e366d34003365b346">sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.4/sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=8c1093880a90c9768c4419e1bbc8cb9788296432b498c38f41844796fe2b3dac">sgl_kernel-0.3.4+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.4.post1/sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=3ec5dac4da6edff73e6225435034aee92b469c51c4a69137786329c57b72ca59">sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.4.post1/sgl_kernel-0.3.4.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=3ac1df6283976723afe3f5daa2d6e4ea1d3ac23850b397dd5612a2fc986face0">sgl_kernel-0.3.4.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.4.post1/sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=9218d6107cb5bda1c15b2657ced4a75bfddf680c1a4b4821121d760f776bceed">sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.4.post1/sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=3ec5dac4da6edff73e6225435034aee92b469c51c4a69137786329c57b72ca59">sgl_kernel-0.3.4.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.5/sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=861652872549a802b72922fc995ff2a58901db6d8d34fabe68fe00ef939fd768">sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.5/sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=3a602ac4a545ef4c5b2804680fcdf29d7468eae49f4dcc00e765f6d2932d1860">sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.5/sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=861652872549a802b72922fc995ff2a58901db6d8d34fabe68fe00ef939fd768">sgl_kernel-0.3.5+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.6/sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=c63d740a63ee944f6e5bff15546515576565a2fea1cdddb99bcdea293ff2b028">sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.6/sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=c63d740a63ee944f6e5bff15546515576565a2fea1cdddb99bcdea293ff2b028">sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.6/sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=42abd39be44154d34298d7f2ad142dda74f945a0cf0340b99bef90b9a5358ff1">sgl_kernel-0.3.6+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.6.post1/sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=8638121325827576e8996e009297efa4f59d7fbcc00324ad217f05886db7a3f7">sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.6.post1/sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl#sha256=f934b46d65f7e9788e31f0b029e03b02da7971c3f1944779fe3f36eba561c2f9">sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.6.post1/sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=8638121325827576e8996e009297efa4f59d7fbcc00324ad217f05886db7a3f7">sgl_kernel-0.3.6.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.6.post2/sgl_kernel-0.3.6.post2+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=6bdde60513ccfd2d7e590ceebaca66b72455b3f5e53ce5b5e7eae4ccda88ed26">sgl_kernel-0.3.6.post2+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.7/sgl_kernel-0.3.7+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=da4665c036f8ec4ed3079326022ee24f3a72dc90bd3d71e4d68762f570fc5a3d">sgl_kernel-0.3.7+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.7.post1/sgl_kernel-0.3.7.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=e3638db21650e15a8577eccbef851d808f6ac0ed9d7fed9c28cd4c6756bb52ec">sgl_kernel-0.3.7.post1+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.8/sgl_kernel-0.3.8+cu129-cp310-abi3-manylinux2014_x86_64.whl#sha256=bafefcfe2ef1d303fcca7d48fff13ab307b62ccb9f19a4ffc4c21d5128c61a8b">sgl_kernel-0.3.8+cu129-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.9/sgl_kernel-0.3.9+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=30ccbe21a0665e8887ef65a0993e80c74a963fb021cf67b85a62e6e6aa207b03">sgl_kernel-0.3.9+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.9/sgl_kernel-0.3.9+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=1612c6af52db870260cb9042edcad1c67e3d07fcce6e65bc4b85c290377dfada">sgl_kernel-0.3.9+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.9/sgl_kernel-0.3.9-cp310-abi3-manylinux2014_aarch64.whl#sha256=e4d623154e81b5e47e9ad0ad8ad5509f0255c8826205e62f097a52193eb7675f">sgl_kernel-0.3.9-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post1/sgl_kernel-0.3.9.post1+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=34520cfdf08d97ea9bdd5edcad4a6b317b79a67c073d3a44f5a8f52da83c3ebe">sgl_kernel-0.3.9.post1+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post1/sgl_kernel-0.3.9.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=e26d05487c23e76e08804c05531fa76e52b058a7b71e427c0152b825f71bd6a4">sgl_kernel-0.3.9.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post1/sgl_kernel-0.3.9.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=1d11eea249f38fa6ec151460d805ba0240f382262195d22d0419ad7b8b17278b">sgl_kernel-0.3.9.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post2/sgl_kernel-0.3.9.post2+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=357eb2a4de102332460bddca26b5b0f982b850e9af0a49c9f7677018e3c3583c">sgl_kernel-0.3.9.post2+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post2/sgl_kernel-0.3.9.post2+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=efcd8b29773583829021a1380213cc826967a2562242cbefba4f0c36ee18bf8c">sgl_kernel-0.3.9.post2+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.9.post2/sgl_kernel-0.3.9.post2-cp310-abi3-manylinux2014_aarch64.whl#sha256=c3080ac21e69b57e96961eeb6dec61cbfe66e95967447368e7e80addd34aeda5">sgl_kernel-0.3.9.post2-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.10/sgl_kernel-0.3.10+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=62dce4e4d8d669a29dbc9cb667b43558a40ac3bfc9ca59e5699fdd6920481956">sgl_kernel-0.3.10+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.10/sgl_kernel-0.3.10+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=f18c766e12bae623b8a09961707cf398c59bbc88ede9bfeaf6c61f61f30075ab">sgl_kernel-0.3.10+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.10/sgl_kernel-0.3.10-cp310-abi3-manylinux2014_aarch64.whl#sha256=1f59ac621fb8ef88fd1cef6a12b55df863e3362e630946f456493a44f1f9d136">sgl_kernel-0.3.10-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.11/sgl_kernel-0.3.11+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=add3297874df45bffd08fffad761b7a6418a91dba330d91fa42952b6e51d4244">sgl_kernel-0.3.11+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.11/sgl_kernel-0.3.11+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=e773fe2245c3d0fd447f9e9b8bfc991dd4ba7d65c52ef53f1d5ca5f80ec0e6d8">sgl_kernel-0.3.11+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.11/sgl_kernel-0.3.11-cp310-abi3-manylinux2014_aarch64.whl#sha256=3dd6e9e2c66d5fac5083b9ef15a2633ad0469bd380954e8a304a2e37bf03f0bc">sgl_kernel-0.3.11-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.12/sgl_kernel-0.3.12+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=befe15f9a154738e72204bd1efcf3d11e11204c4e9519878700cd5fe41573614">sgl_kernel-0.3.12+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.12/sgl_kernel-0.3.12+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=c47b2205b709710d47f4fae4ea08e348a43c9f6d62e40b2a6e2091bf29f5a308">sgl_kernel-0.3.12+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.12/sgl_kernel-0.3.12-cp310-abi3-manylinux2014_aarch64.whl#sha256=d070becb9d432a4077d9af9cca10f43759436211ac82b58bf94840b2f187b86c">sgl_kernel-0.3.12-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.13/sgl_kernel-0.3.13+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=585f7d170c21a7eeba829323366e8f1553a33a0595c1b008907752cbaf175ebd">sgl_kernel-0.3.13+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.13/sgl_kernel-0.3.13-cp310-abi3-manylinux2014_aarch64.whl#sha256=c248ca28b91d5d1a64416129276092105b47f2b5819d56d56b8da6902109a68c">sgl_kernel-0.3.13-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.14/sgl_kernel-0.3.14+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=401b0217614cd5b866ba8e47834881d5cb936baede80b8a25b86b7dd97970f13">sgl_kernel-0.3.14+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.14/sgl_kernel-0.3.14-cp310-abi3-manylinux2014_aarch64.whl#sha256=9360439a0c7edd335bd841464d8c3c4e95f5133d80af17b8d6b5ffaa75c512be">sgl_kernel-0.3.14-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.14.post1/sgl_kernel-0.3.14.post1+cu124-cp310-abi3-manylinux2014_x86_64.whl#sha256=83f4372b9564d60e734a8601eba5864413f80851557d1833aeed73897c16d887">sgl_kernel-0.3.14.post1+cu124-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.14.post1/sgl_kernel-0.3.14.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl#sha256=d799e3df31a782320ab5a9cd4a94d1fd962aace3cf9aa565dfd449009786db7c">sgl_kernel-0.3.14.post1+cu128-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.14.post1/sgl_kernel-0.3.14.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=6aa383d27e731cd3b49b63ff8d05f75556ca8cdf1697c99668d835155515dc53">sgl_kernel-0.3.14.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.15/sgl_kernel-0.3.15-cp310-abi3-manylinux2014_x86_64.whl#sha256=3f1745a899af5d69355367859d13615e72fa8294750629913de56507c073aa43">sgl_kernel-0.3.15-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.15/sgl_kernel-0.3.15-cp310-abi3-manylinux2014_aarch64.whl#sha256=f6e7e1b39fd26e85f8e8b17c00b92b51b0cf591e61f78d0e1621737553a6f2a7">sgl_kernel-0.3.15-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.15/sgl_kernel-0.3.15-cp310-abi3-manylinux2014_x86_64.whl#sha256=3f1745a899af5d69355367859d13615e72fa8294750629913de56507c073aa43">sgl_kernel-0.3.15-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16/sgl_kernel-0.3.16-cp310-abi3-manylinux2014_aarch64.whl#sha256=4d53f3fca04c2bf52775ae5292d2dcc329a75876534433d85378c17d333675d3">sgl_kernel-0.3.16-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16/sgl_kernel-0.3.16-cp310-abi3-manylinux2014_aarch64.whl#sha256=4d53f3fca04c2bf52775ae5292d2dcc329a75876534433d85378c17d333675d3">sgl_kernel-0.3.16-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16/sgl_kernel-0.3.16-cp310-abi3-manylinux2014_x86_64.whl#sha256=a34f7e60952c3435dd3e79d9e9723d394e3a2493282a52b0c552e1b531225f3c">sgl_kernel-0.3.16-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post1/sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=4e4f697f5d01ca8973a7229d989dd4a9d4a21353fc62c66d1080fced31e59980">sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post1/sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=96dd0f0b348ea616d29f5c1ab38f6134766f3c37be2922e1f0a3de4229d161b8">sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post1/sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=4e4f697f5d01ca8973a7229d989dd4a9d4a21353fc62c66d1080fced31e59980">sgl_kernel-0.3.16.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post2/sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_x86_64.whl#sha256=3dd529aeac9b6b7bc98be0b1f24c964eab376b4c764aa6220615c3574b27f826">sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post2/sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_aarch64.whl#sha256=907421ab56d51f1be66a9f7a13f0a397e93080314911774f34063f851782680f">sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post2/sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_x86_64.whl#sha256=3dd529aeac9b6b7bc98be0b1f24c964eab376b4c764aa6220615c3574b27f826">sgl_kernel-0.3.16.post2-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post3/sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_x86_64.whl#sha256=d12f1250233e2716db1b5096cfc4eb9ac1bfe6391ae4e40762be73210159bdf0">sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post3/sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_aarch64.whl#sha256=f144d83b6f3dd490ae6a89385ac72ef0857a1d9b0e6d59a516d485029cf4e571">sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post3/sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_x86_64.whl#sha256=d12f1250233e2716db1b5096cfc4eb9ac1bfe6391ae4e40762be73210159bdf0">sgl_kernel-0.3.16.post3-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post4/sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_aarch64.whl#sha256=d070f0206227c04294a15e4e081b935594bdfb9e8dad5a893bde02ce568a1fc9">sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post4/sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_x86_64.whl#sha256=12ffce253873df2433ed3df02b2a45f04e49d13edc3d965d284c2186ba291e5c">sgl_kernel-0.3.16.post4-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post5/sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_aarch64.whl#sha256=ecaf7b8f1e22b82c873c7bed43e7f18d612d683652a31a8f7df483c752d35ffb">sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post5/sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_x86_64.whl#sha256=3a81ecd6398ec0878f0992bbc7fe9434627cd93d8240808d396c2385f8021c8f">sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post6/sgl_kernel-0.3.16.post6-cp310-abi3-manylinux2014_aarch64.whl#sha256=07cf069698e7570ff4c740fdfdc620c09697ad8bf480815e7c490a1924599c5e">sgl_kernel-0.3.16.post6-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.16.post6/sgl_kernel-0.3.16.post6-cp310-abi3-manylinux2014_x86_64.whl#sha256=78e58824a0d7280dec7b4d9a6db79435930227b2cb41ed92343a02b41d32ec63">sgl_kernel-0.3.16.post6-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.17/sgl_kernel-0.3.17-cp310-abi3-manylinux2014_aarch64.whl#sha256=688401e2bb16c2ca5d4e1433d5e8851ab9a77dd5dac99983e99b3e748a2916f0">sgl_kernel-0.3.17-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.17/sgl_kernel-0.3.17-cp310-abi3-manylinux2014_x86_64.whl#sha256=255af7d14a671059e5faebf3d897e08d2e522bdc04549d2205b9dd9844ebad29">sgl_kernel-0.3.17-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post1/sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=330057ad2d239e9363ee9abd85ed445ee1795161c60b7357f9792103121039cc">sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post1/sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=c864e6d6eebcd91e59a71ba781739761a21774f0cb862578381f54f504f93b4a">sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post1/sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=9f9c16d9a66c37660135065f0cebab2a7c28273111ea934c62fa4fa3ef3011a2">sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post1/sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=864f3d93dfc6a0adbb6bc07fcdad0daf7cd714be671829a87296e57d88331e25">sgl_kernel-0.3.17.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post2/sgl_kernel-0.3.17.post2-cp310-abi3-manylinux2014_aarch64.whl#sha256=19a0b7bfa1d0e172998ba2efd0485aa899ede304388c4df84be7223e0d787478">sgl_kernel-0.3.17.post2-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.17.post2/sgl_kernel-0.3.17.post2-cp310-abi3-manylinux2014_x86_64.whl#sha256=4e534863487a2484fa452de118478503a9f471f6d952b0c5616c9b980adef548">sgl_kernel-0.3.17.post2-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.18/sgl_kernel-0.3.18-cp310-abi3-manylinux2014_aarch64.whl#sha256=5b137b890b8110dbe4500d505b0436eadaf3e1a1f3c986711c581f5a19ec7bb1">sgl_kernel-0.3.18-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.18/sgl_kernel-0.3.18-cp310-abi3-manylinux2014_x86_64.whl#sha256=27790bf729a496750433753de6d38b82117b126b4919124649c9b8a4169b6617">sgl_kernel-0.3.18-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post1/sgl_kernel-0.3.18.post1-cp310-abi3-manylinux2014_aarch64.whl#sha256=df0052154ab3952b3500dc753260c7f05f890e3e6eaa4e5fc9f77884378db68e">sgl_kernel-0.3.18.post1-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post1/sgl_kernel-0.3.18.post1-cp310-abi3-manylinux2014_x86_64.whl#sha256=0e6fabb2709b951afd75b4f9ffe2d5faaa6ca2dcbaf8f93855770807cf4f924b">sgl_kernel-0.3.18.post1-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post2/sgl_kernel-0.3.18.post2-cp310-abi3-manylinux2014_aarch64.whl#sha256=c313d9393035f2c8e466eb51013e1254648fa8187206de6b3258e64b26e55161">sgl_kernel-0.3.18.post2-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post2/sgl_kernel-0.3.18.post2-cp310-abi3-manylinux2014_x86_64.whl#sha256=15eb39084139f1901ec5d24e9ff46ad87b5f98f8a42399237662ada5de7e5774">sgl_kernel-0.3.18.post2-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post3/sgl_kernel-0.3.18.post3-cp310-abi3-manylinux2014_aarch64.whl#sha256=957a8cc3c6adf7f8ae543eda1c00452e095706f961c01cbeb60da28d40b63c07">sgl_kernel-0.3.18.post3-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.18.post3/sgl_kernel-0.3.18.post3-cp310-abi3-manylinux2014_x86_64.whl#sha256=5b34cf189a320e194e018aebcbae5230b615db61e68106932c2e95181c8299f1">sgl_kernel-0.3.18.post3-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.19/sgl_kernel-0.3.19-cp310-abi3-manylinux2014_aarch64.whl#sha256=db09851871c41416930e382f7d3a12b94705637891d2ec85dae56262abe26482">sgl_kernel-0.3.19-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.19/sgl_kernel-0.3.19-cp310-abi3-manylinux2014_x86_64.whl#sha256=477e123f272f18de6641e23175c63749f32e9d792ea53d52b9ade30238877b61">sgl_kernel-0.3.19-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl#sha256=d9f65e015b4b8fb163c05d8a549a9cf9058e6346380ed8dc184e951a9af95581">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl#sha256=f283c94e936bb24ef01700cd49ee8f1edee3e13b84ba9a268e2b9ae6dbb93924">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl#sha256=75d7337e90fdfe2517abebd6cb87e4cb4710fb814e6e6e9bcf541b7843f742c7">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl#sha256=2441382167205b7586ea6c253969fa87b58124256fe55ef27251a2c5d67739cc">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl#sha256=8ecfe783908f823d91f344ad4c0b68b40bae7f540795337189cc1c7dd993b345">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.20/sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl#sha256=f3133def78d9811c13407fcbc0b3fdf714b89eafd4e90b87d389b2d60173fbc9">sgl_kernel-0.3.20-cp310-abi3-manylinux2014_x86_64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.21/sgl_kernel-0.3.21-cp310-abi3-manylinux2014_aarch64.whl#sha256=bafdcc26e9ce1e9102b99e4186d652fefbafe5c22ea2cbb5ffe07b331e83be1f">sgl_kernel-0.3.21-cp310-abi3-manylinux2014_aarch64.whl</a><br>
+<a
+    href="https://github.com/sgl-project/whl/releases/download/v0.3.21/sgl_kernel-0.3.21-cp310-abi3-manylinux2014_x86_64.whl#sha256=e7f66eb6a149ae2d1ea5a5bc29bc14cbb4322a23952d8d861eedbb253850c90f">sgl_kernel-0.3.21-cp310-abi3-manylinux2014_x86_64.whl</a><br>


### PR DESCRIPTION
Replace outdated hash for sgl-kernel v0.3.21 in cu129.

From this error:
> ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.
>     sgl-kernel==0.3.21 from https://github.com/sgl-project/whl/releases/download/v0.3.21/sgl_kernel-0.3.21-cp310-abi3-manylinux2014_x86_64.whl#sha256=57dfb3a2a3cd759f499c32e2bad5f6489b7c58f7f9a84ee00c53ec92d303aaab (from sglang==0.5.8.dev0+g0189f41c3):
>         Expected sha256 57dfb3a2a3cd759f499c32e2bad5f6489b7c58f7f9a84ee00c53ec92d303aaab
>              Got        e7f66eb6a149ae2d1ea5a5bc29bc14cbb4322a23952d8d861eedbb253850c90f