### PR TITLE
Add musa43

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,3 +8,4 @@
 <a href="nightly/">nightly</a><br>
 <a href="rocm700/">rocm700</a><br>
 <a href="rocm711/">rocm711</a><br>
+<a href="musa43/">musa43</a><br>

--- a/musa43/index.html
+++ b/musa43/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<a href="sgl-kernel/">sgl-kernel</a>

--- a/musa43/sgl-kernel/index.html
+++ b/musa43/sgl-kernel/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<h1>SGLang Kernel Library Wheels for MUSA 4.3</h1>


### PR DESCRIPTION
The MUSA SDK follows semantic versioning (`major.minor.patch`), so we use the latest release, `musa 4.3`, here. More details can be found at: https://developer.mthreads.com/sdk/download/musa