### PR TITLE
cu132 index

### DIFF
--- a/cu132/index.html
+++ b/cu132/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<a href="sgl-kernel/">sgl-kernel</a>

--- a/cu132/sgl-kernel/index.html
+++ b/cu132/sgl-kernel/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<h1>SGLang Kernel Library Wheels for CUDA 13.2</h1>


### PR DESCRIPTION
CUDA 13.2 is released on 3/9, creating issue tracker for CUDA 13.2 binaries enablement.

New features in 13.2:

[NVIDIA CUDA Tile](https://developer.nvidia.com/cuda/tile) is now supported on devices of compute capability 8.X architectures (NVIDIA Ampere and NVIDIA Ada), as well as 10.X and 12.X architectures (NVIDIA Blackwell)
Unified CUDA Toolkit for Arm targets
Support for recursive functions and closures in cuTile Python
Support for emulated FP64 in math libraries
Numba-CUDA debugging to developer tools
CUDA Graphs to cuda.core
See https://developer.nvidia.com/blog/cuda-13-2-introduces-enhanced-cuda-tile-support-and-new-python-features/ for more comprehensive notes.