### PR TITLE
add xpu/ directory index

### DIFF
--- a/xpu/index.html
+++ b/xpu/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<a href="sglang-kernel-xpu/">sglang-kernel-xpu</a><br>


### PR DESCRIPTION
Follow-up to #26, which registered `xpu` in the root `index.html`.

`xpu/` is the only backend directory without an `index.html` of its own, so the link added in #26 leads to a 404 — every other backend (`rocm720/`, `cu130/`, `musa43/`, …) has one listing its packages. This adds the missing listing, in the same form as `rocm720/index.html`.

pip is not affected either way: it requests the PEP 503 path `https://docs.sglang.io/whl/xpu/sglang-kernel-xpu/`, which already serves correctly, and `pip download sglang-kernel-xpu==0.1.0 --index-url https://docs.sglang.io/whl/xpu` succeeds today. This only restores the browsable listing.

Not included here: `xpu/sglang-kernel-xpu/index.html` currently holds two entries for the same wheel filename with different sha256 (`63305ad0…` from the 2026-08-21 build, `19f23a05…` from the 2026-08-31 rebuild; the published asset is `19f23a05…`). A fresh run of `release-whl-kernel-xpu.yml` is in flight and will append a third entry under the new `v0.1.0+xpu` tag, so that file is best cleaned up once the run lands and the final hash is known. sgl-project/sglang#37218 stops the duplication recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
